### PR TITLE
Non-dot

### DIFF
--- a/.changeset/strange-coats-eat.md
+++ b/.changeset/strange-coats-eat.md
@@ -1,0 +1,5 @@
+---
+'@repobuddy/jest': patch
+---
+
+Exclude files like `a_spec.ts` as tests

--- a/packages/jest/ts/configs/electron.ts
+++ b/packages/jest/ts/configs/electron.ts
@@ -4,11 +4,11 @@ import { knownRunners, knownTestEnvironments } from '../fields/index.js'
 export const electron = {
   runner: knownRunners.electron,
   testEnvironment: knownTestEnvironments.node,
-  testMatch: ['**/?*.(spec|test|unit|accept|integrate|system)?(.electron).(js|jsx|cjs|mjs|ts|tsx|cts|mts)']
+  testMatch: ['**/?*\\.(spec|test|unit|accept|integrate|system)?(.electron).(js|jsx|cjs|mjs|ts|tsx|cts|mts)']
 } satisfies Config
 
 export const electronRenderer = {
   runner: knownRunners.electronRenderer,
   testEnvironment: knownTestEnvironments.electron,
-  testMatch: ['**/?*.(spec|test|unit|accept|integrate|system).(js|jsx|cjs|mjs|ts|tsx|cts|mts)']
+  testMatch: ['**/?*\\.(spec|test|unit|accept|integrate|system).(js|jsx|cjs|mjs|ts|tsx|cts|mts)']
 } satisfies Config

--- a/packages/jest/ts/configs/jsdom.ts
+++ b/packages/jest/ts/configs/jsdom.ts
@@ -3,5 +3,5 @@ import { knownTestEnvironments } from '../fields/index.js'
 
 export const jsdom = {
   testEnvironment: knownTestEnvironments.jsdom,
-  testMatch: ['**/?*.(spec|test|unit|accept|integrate|system)?(.jsdom).(js|jsx|cjs|mjs|ts|tsx|cts|mts)']
+  testMatch: ['**/?*\\.(spec|test|unit|accept|integrate|system)?(.jsdom).(js|jsx|cjs|mjs|ts|tsx|cts|mts)']
 } satisfies Config

--- a/packages/jest/ts/configs/node.ts
+++ b/packages/jest/ts/configs/node.ts
@@ -14,13 +14,13 @@ export function configNode(
     (_, i) => i + minNodeVersion
   )
 
-  const testRegex = [`(${id})(\\.node)?\\.(js|jsx|cjs|mjs|ts|tsx|cts|mts)$`].concat(
-    nodeVersions.map((v) => `(${id})\\.node${v}\\.(js|jtx|cjs|mjs|ts|tsx|cts|mts)$`)
+  const testRegex = [`\\.(${id})(\\.node)?\\.(js|jsx|cjs|mjs|ts|tsx|cts|mts)$`].concat(
+    nodeVersions.map((v) => `\\.(${id})\\.node${v}\\.(js|jtx|cjs|mjs|ts|tsx|cts|mts)$`)
   )
 
   return {
     // `(\\.node.\*)?` looks too eager, but can't find a better solution yet.
-    coveragePathIgnorePatterns: [`(${id})(\\.node.\*)?\\.(js|jsx|cjs|mjs|ts|tsx|cts|mts)$`],
+    coveragePathIgnorePatterns: [`\\.(${id})(\\.node.\*)?\\.(js|jsx|cjs|mjs|ts|tsx|cts|mts)$`],
     testEnvironment: knownTestEnvironments.node,
     testRegex
   } satisfies Config

--- a/testcases/js-cjs/source/not_a_spec.js
+++ b/testcases/js-cjs/source/not_a_spec.js
@@ -1,0 +1,1 @@
+console.log('this is not a spec file')

--- a/testcases/js-esm/js/not_a_spec.js
+++ b/testcases/js-esm/js/not_a_spec.js
@@ -1,0 +1,1 @@
+console.log('this is not a spec file')

--- a/testcases/jsdom-ts/src/not_a_spec.ts
+++ b/testcases/jsdom-ts/src/not_a_spec.ts
@@ -1,0 +1,1 @@
+console.log('this is not a spec file')

--- a/testcases/ts-cjs/src/not_a_spec.ts
+++ b/testcases/ts-cjs/src/not_a_spec.ts
@@ -1,0 +1,1 @@
+console.log('this is not a spec file')

--- a/testcases/ts-esm/ts/not_a_spec.ts
+++ b/testcases/ts-esm/ts/not_a_spec.ts
@@ -1,0 +1,1 @@
+console.log('this is not a spec file')


### PR DESCRIPTION
e.g. `a_spec.js` or `b_test.ts`